### PR TITLE
:tada: Work on Organization that already use project-bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # <img src='assets/pj-card-bot-192x192.png' width='32' alt='pj-icon'> PJ Card Bot
 
-⚠️ **This bot doesn't work on Organization yet.**
-
 🤖 A GitHub App built with [Probot](https://github.com/probot/probot) that automatically adding cards of Issue/Pull Request on a Project board.
 
 This bot is inspired by [philschatz/project-bot](https://github.com/philschatz/project-bot).
@@ -14,7 +12,7 @@ Go to the [GitHub App page](https://github.com/apps/pj-card-bot) and click `Inst
 
 Unlike the project-bot, the PJ Card Bot has the following specifications.
 
-- The automation card must be at the bottom of a column.
+- The automation rule card must be at the bottom of a column and set `PJ Card Bot Rules` in the heading.
 - Only three rules can be set, `new_issue`, `new_pullrequest`, and `added_label`.
 - When `added_label`, a new card is added to the project. (This is my motivation for creating this bot.)
 
@@ -23,7 +21,7 @@ Unlike the project-bot, the PJ Card Bot has the following specifications.
 The way to set the Automation Card is almost the same as the project-bot.
 
 ```md
-###### Automation Rules
+###### PJ Card Bot Rules
 
 <!-- Documentation: https://github.com/daido1976/pj-card-bot -->
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -6,6 +6,13 @@ export const parseMarkdownToRules = (
   const rules: { ruleName: string; ruleArgs: string[] }[] = [];
   // FIXME: Update src/@types/marked/index.d.ts & Do not use any type
   const tokens: any = marked.lexer(note);
+
+  // Return no rules, if note has invalid heading
+  const headingToken = tokens.find((token: any) => token.type === "heading");
+  if (headingToken.text !== "PJ Card Bot Rules") {
+    return [];
+  }
+
   const listToken = tokens.find((token: any) => token.type === "list");
 
   listToken.items.forEach((listItem: any) => {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -8,6 +8,7 @@ export const parseMarkdownToRules = (
   const tokens: any = marked.lexer(note);
 
   // Return no rules, if the note has an invalid heading or no heading
+  // Don't care about depth of heading
   const headingToken = tokens.find((token: any) => token.type === "heading");
   if (headingToken?.text !== "PJ Card Bot Rules") {
     return [];

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -7,7 +7,7 @@ export const parseMarkdownToRules = (
   // FIXME: Update src/@types/marked/index.d.ts & Do not use any type
   const tokens: any = marked.lexer(note);
 
-  // Return no rules, if note has invalid heading
+  // Return no rules, if the note has an invalid heading or no heading
   const headingToken = tokens.find((token: any) => token.type === "heading");
   if (headingToken?.text !== "PJ Card Bot Rules") {
     return [];

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -9,7 +9,7 @@ export const parseMarkdownToRules = (
 
   // Return no rules, if note has invalid heading
   const headingToken = tokens.find((token: any) => token.type === "heading");
-  if (headingToken.text !== "PJ Card Bot Rules") {
+  if (headingToken?.text !== "PJ Card Bot Rules") {
     return [];
   }
 

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -3,7 +3,7 @@ import { parseMarkdownToRules } from "../src/parser";
 describe("parseMarkdownToRules", () => {
   describe("when note is valid", () => {
     const note: string =
-      "###### Automation Rules\r\n" +
+      "###### PJ Card Bot Rules\r\n" +
       "\r\n" +
       "<!-- Documentation: https://github.com/philschatz/project-bot -->\r\n" +
       "\r\n" +

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -31,7 +31,7 @@ describe("parseMarkdownToRules", () => {
     });
   });
 
-  describe("when note has invalid title", () => {
+  describe("when note has invalid heading", () => {
     const note: string =
       "###### Automation Rules\r\n" +
       "\r\n" +

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,31 +1,33 @@
 import { parseMarkdownToRules } from "../src/parser";
 
 describe("parseMarkdownToRules", () => {
-  const note: string =
-    "###### Automation Rules\r\n" +
-    "\r\n" +
-    "<!-- Documentation: https://github.com/philschatz/project-bot -->\r\n" +
-    "\r\n" +
-    "- `added_label` **wontfix**\r\n" +
-    "- `new_pullrequest` **repo1** **repo2**\r\n" +
-    "- `new_issue`";
+  describe("when note is valid", () => {
+    const note: string =
+      "###### Automation Rules\r\n" +
+      "\r\n" +
+      "<!-- Documentation: https://github.com/philschatz/project-bot -->\r\n" +
+      "\r\n" +
+      "- `added_label` **wontfix**\r\n" +
+      "- `new_pullrequest` **repo1** **repo2**\r\n" +
+      "- `new_issue`";
 
-  const results: { ruleName: string; ruleArgs: string[] }[] = [
-    {
-      ruleName: "added_label",
-      ruleArgs: ["wontfix"],
-    },
-    {
-      ruleName: "new_pullrequest",
-      ruleArgs: ["repo1", "repo2"],
-    },
-    {
-      ruleName: "new_issue",
-      ruleArgs: [],
-    },
-  ];
+    const results: { ruleName: string; ruleArgs: string[] }[] = [
+      {
+        ruleName: "added_label",
+        ruleArgs: ["wontfix"],
+      },
+      {
+        ruleName: "new_pullrequest",
+        ruleArgs: ["repo1", "repo2"],
+      },
+      {
+        ruleName: "new_issue",
+        ruleArgs: [],
+      },
+    ];
 
-  it("parses markdown to rules", () => {
-    expect(parseMarkdownToRules(note)).toEqual(results);
+    it("parses markdown to rules", () => {
+      expect(parseMarkdownToRules(note)).toEqual(results);
+    });
   });
 });

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -48,6 +48,19 @@ describe("parseMarkdownToRules", () => {
     });
   });
 
+  describe("when note does not have heading", () => {
+    const note: string =
+      "- `added_label` **wontfix**\r\n" +
+      "- `new_pullrequest` **repo1** **repo2**\r\n" +
+      "- `new_issue`";
+
+    const results: { ruleName: string; ruleArgs: string[] }[] = [];
+
+    it("returns empty array", () => {
+      expect(parseMarkdownToRules(note)).toEqual(results);
+    });
+  });
+
   describe("when note has invalid list", () => {
     const note: string =
       "###### PJ Card Bot Rules\r\n" +

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -30,4 +30,45 @@ describe("parseMarkdownToRules", () => {
       expect(parseMarkdownToRules(note)).toEqual(results);
     });
   });
+
+  describe("when note has invalid title", () => {
+    const note: string =
+      "###### Automation Rules\r\n" +
+      "\r\n" +
+      "<!-- Documentation: https://github.com/philschatz/project-bot -->\r\n" +
+      "\r\n" +
+      "- `added_label` **wontfix**\r\n" +
+      "- `new_pullrequest` **repo1** **repo2**\r\n" +
+      "- `new_issue`";
+
+    const results: { ruleName: string; ruleArgs: string[] }[] = [];
+
+    it("returns empty array", () => {
+      expect(parseMarkdownToRules(note)).toEqual(results);
+    });
+  });
+
+  describe("when note has invalid list", () => {
+    const note: string =
+      "###### PJ Card Bot Rules\r\n" +
+      "- `added_label` **wontfix**\r\n" +
+      "- new_pullrequest repo1 **repo2**\r\n" +
+      "- `new_issue`";
+
+    const results: { ruleName: string; ruleArgs: string[] }[] = [
+      {
+        ruleName: "added_label",
+        ruleArgs: ["wontfix"],
+      },
+      {
+        ruleName: "new_issue",
+        ruleArgs: [],
+      },
+    ];
+
+    // Not implemented yet
+    xit("parses markdown to rules only valid listitem", () => {
+      expect(parseMarkdownToRules(note)).toEqual(results);
+    });
+  });
 });


### PR DESCRIPTION
## Why

project-bot をすでに運用している organization のリポジトリで使用すると以下の不具合が出たので直す。

- ~Repository access を許可してない他のリポジトリのやつも全部 webhook くる（権限もらってるのは organization projects だから一つのリポジトリで許可すれば全部くる？）~
- webhook リクエストが来るのはやっぱり Repository access を許可してもらったリポジトリのみだった、その後の GraphQL API のレスポンスでは owner に紐づく全ての projects の lastCard が入ってくる（そういう query を叩いてるため）ので勘違いしていた
- 👆 の通り、lastCard 自体は organization の全ての project のものが入ってくるので、rule card の書き方が同じだと project-bot と競合する
- というかそもそも rule card の書き方が不正だった時（使用通りのリストになってないとか）普通に 
`Cannot read property 'hoge' of undefined` のエラーで落ちちゃう

## How

project-bot と競合しないように、また他の不正な note に惑わされないように見出しに `##### PJ Card Bot Rules` をつける仕様にしてプログラムでパースして存在チェック、それ以外の見出しだった場合は無視するようにした。

## Note

- 不正な markdown（不正なリストとか）入ってきた場合考慮する？
    - 実際に何度か起きてから考えれば良い、今は普通にエラー raise させておくだけで特になにもしない（テストケースだけ書いておいた）